### PR TITLE
update for rc2

### DIFF
--- a/config/default_kabanero_config.yaml
+++ b/config/default_kabanero_config.yaml
@@ -5,11 +5,11 @@ version: 0.6.0
 stacks:
   - name: kabanero-stack-hub
     repos:
-      - url: https://github.com/kabanero-io/collections/releases/download/0.6.0-rc.2/java-openliberty-0.2.1-index.yaml
-      - url: https://github.com/kabanero-io/collections/releases/download/0.6.0-rc.2/java-spring-boot2-0.3.23-index.yaml
-      - url: https://github.com/kabanero-io/collections/releases/download/0.6.0-rc.2/nodejs-0.3.1-index.yaml
-      - url: https://github.com/kabanero-io/collections/releases/download/0.6.0-rc.2/nodejs-express-0.2.8-index.yaml
-      - url: https://github.com/kabanero-io/collections/releases/download/0.6.0-rc.2/java-microprofile-0.2.25-index.yaml
+      - url: https://github.com/kabanero-io/collections/releases/download/0.6.0-rc.3/java-openliberty-0.2.2-index.yaml
+      - url: https://github.com/kabanero-io/collections/releases/download/0.6.0-rc.3/java-spring-boot2-0.3.23-index.yaml
+      - url: https://github.com/kabanero-io/collections/releases/download/0.6.0-rc.3/nodejs-0.3.2-index.yaml
+      - url: https://github.com/kabanero-io/collections/releases/download/0.6.0-rc.3/nodejs-express-0.2.9-index.yaml
+      - url: https://github.com/kabanero-io/collections/releases/download/0.6.0-rc.3/java-microprofile-0.2.25-index.yaml
 image-org:
 image-registry:
 nginx-image-name:


### PR DESCRIPTION
Update for rc2 of kabanero stack hub.

Picks up rc3 of collection based stacks.