### PR TITLE
quarkus 0.3.6

### DIFF
--- a/config/default_kabanero_config.yaml
+++ b/config/default_kabanero_config.yaml
@@ -8,7 +8,7 @@ stacks:
       - url: https://github.com/kabanero-io/collections/releases/download/0.9.0-rc.1/java-spring-boot2-0.3.29-index.yaml
       - url: https://github.com/kabanero-io/collections/releases/download/0.9.0-rc.1/nodejs-0.3.6-index.yaml
       - url: https://github.com/kabanero-io/collections/releases/download/0.9.0-rc.1/nodejs-express-0.4.8-index.yaml
-      - url: https://github.com/appsody/stacks/releases/download/quarkus-v0.3.5/incubator-index.yaml
+      - url: https://github.com/appsody/stacks/releases/download/quarkus-v0.3.6/incubator-index.yaml
         include: 
           - quarkus
       - url: https://github.com/appsody/stacks/releases/download/java-openliberty-v0.2.12/incubator-index.yaml


### PR DESCRIPTION
We'd like to pull this into Kabanero 0.9 so that the Quarkus stack includes support for auto-binding to Prometheus via the Appsody Operator.